### PR TITLE
orangepi-docker-image: add persistent /data partition support

### DIFF
--- a/recipes-core/images/orangepi-docker-image.bb
+++ b/recipes-core/images/orangepi-docker-image.bb
@@ -3,6 +3,8 @@ SUMMARY = "Orange Pi Image with Docker and K3S support, No Graphics"
 require base-dev-image.inc
 
 IMAGE_INSTALL += " \
+    datapartition-root \
+    datapartition-docker \
     docker-ce \
     k3s \
 "


### PR DESCRIPTION
This enables storing persistent data in /data directory, which will be kept throughout SD card updates